### PR TITLE
This allows jukebox to play through walls.

### DIFF
--- a/code/datums/sound_player.dm
+++ b/code/datums/sound_player.dm
@@ -27,13 +27,13 @@ var/decl/sound_player/sound_player = new()
 	taken_channels = list()
 	source_id_uses = list()
 
-/decl/sound_player/proc/PlayLoopingSound(var/atom/source, var/sound_id, var/sound, var/volume, var/range, var/falloff, var/prefer_mute)
+/decl/sound_player/proc/PlayLoopingSound(var/atom/source, var/sound_id, var/sound, var/volume, var/range, var/falloff, var/prefer_mute, var/ignore_vis = FALSE)
 	var/channel = PrivGetChannel(sound_id)
 	if(!channel)
 		log_warning("All available sound channels are in active use.")
 		return
 
-	return new/datum/sound_token(source, sound_id, sound, volume, channel, range, falloff, prefer_mute)
+	return new/datum/sound_token(source, sound_id, sound, volume, channel, range, falloff, prefer_mute, ignore_vis)
 
 /decl/sound_player/proc/PrivStopSound(var/datum/sound_token/sound_token)
 	var/channel = sound_token.channel
@@ -83,8 +83,9 @@ var/decl/sound_player/sound_player = new()
 
 	var/datum/proximity_trigger/square/proxy_listener
 	var/list/can_be_heard_from
+	var/ignore_vis = FALSE
 
-/datum/sound_token/New(var/atom/source, var/sound_id, var/sound, var/volume, var/channel, var/range = 4, var/falloff = 1, var/prefer_mute = FALSE)
+/datum/sound_token/New(var/atom/source, var/sound_id, var/sound, var/volume, var/channel, var/range = 4, var/falloff = 1, var/prefer_mute = FALSE, var/ignore_vis = FALSE)
 	..()
 	listeners = list()
 	listener_status = list()
@@ -97,6 +98,7 @@ var/decl/sound_player/sound_player = new()
 	src.sound_id = sound_id
 	src.source = source
 	src.volume = volume
+	src.ignore_vis = ignore_vis
 
 	destroyed_event.register(source, src, /datum/sound_token/proc/Stop)
 
@@ -149,7 +151,8 @@ datum/sound_token/proc/Mute()
 		return
 
 	can_be_heard_from = current_turfs
-	var/current_listeners = all_hearers(source, range)
+	var/current_listeners = all_hearers(source, range, ignore_vis)
+
 	var/former_listeners = listeners - current_listeners
 	var/new_listeners = current_listeners - listeners
 
@@ -205,7 +208,8 @@ datum/sound_token/proc/PrivAddListener(var/atom/listener)
 	var/turf/listener_turf = get_turf(listener)
 
 	var/distance = get_dist(source_turf, listener_turf)
-	if(!listener_turf || (distance > range) || !(listener_turf in can_be_heard_from))
+
+	if(!listener_turf || (distance > range) || (!(listener_turf in can_be_heard_from) && !ignore_vis) )
 		if(prefer_mute)
 			listener_status[listener] |= SOUND_MUTE
 		else

--- a/code/game/machinery/jukebox.dm
+++ b/code/game/machinery/jukebox.dm
@@ -206,7 +206,8 @@ datum/track/New(var/title_name, var/audio)
 		return
 
 	// Jukeboxes cheat massively and actually don't share id. This is only done because it's music rather than ambient noise.
-	sound_token = sound_player.PlayLoopingSound(src, sound_id, current_track.sound, volume = volume, range = 7, falloff = 3, prefer_mute = TRUE)
+	// It also has the "ignore_vis" flag so it can be heard through walls and zlevels
+	sound_token = sound_player.PlayLoopingSound(src, sound_id, current_track.sound, volume = volume, range = 14, falloff = 3, prefer_mute = TRUE, ignore_vis = TRUE)
 
 	playing = 1
 	update_use_power(2)

--- a/code/modules/mob/observer/virtual/helpers.dm
+++ b/code/modules/mob/observer/virtual/helpers.dm
@@ -46,13 +46,18 @@
 // Thus, unlike viewing hearing is communicative. I.e. if Mob A can hear Mob B then Mob B can also hear Mob A.
 
 // Gets the hosts of all the virtual mobs that can hear the given movable atom (or rather, it's virtual mob or turf in that existence order)
-/proc/all_hearers(var/atom/movable/heard_vmob, var/range = world.view)
+/proc/all_hearers(var/atom/movable/heard_vmob, var/range = world.view, var/ignore_vis = FALSE)
 	. = list()
 
 	ACQUIRE_VIRTUAL_OR_TURF(heard_vmob)
-	for(var/mob/observer/virtual/v_mob in hearers(range, heard_vmob))
-		if(v_mob.abilities & VIRTUAL_ABILITY_HEAR)
-			. |= v_mob.host
+	if(ignore_vis)
+		for(var/mob/observer/virtual/v_mob in range(range, heard_vmob))
+			if(v_mob.abilities & VIRTUAL_ABILITY_HEAR)
+				. |= v_mob.host
+	else
+		for(var/mob/observer/virtual/v_mob in hearers(range, heard_vmob))
+			if(v_mob.abilities & VIRTUAL_ABILITY_HEAR)
+				. |= v_mob.host
 
 /***************
 * View Helpers *


### PR DESCRIPTION
Modifies a few sound related procs with a line of sight override.
Extends jukebox range to 14 tiles.

Yes, jukebox can be heard in space, this was already the case before.
This shouldn't cause any problems as the override is not enabled by default.